### PR TITLE
Adds NYPL brand colors

### DIFF
--- a/components/_patterns/00-base/global/01-colors/_color-vars.scss
+++ b/components/_patterns/00-base/global/01-colors/_color-vars.scss
@@ -1,12 +1,35 @@
-// Grayscale
+// Neutrals
 $white: white;
-$near-white: #f2f2f2;
-$gray-lightest: #e5e5e5;
-$gray-lighter: #ccc;
-$gray-light: #999;
-$gray: #666;
-$gray-dark: #4c4c4c;
-$gray-darker: #333;
+$gray-xxlight: #fafafa;
+$gray-xlight: #f5f5f5;
+$gray-light: #e0e0e0;
+$gray-medium: #bdbdbd;
+$gray-dark: #616161;
+$gray-xdark: #424242;
 $black: black;
 
-// Project
+// Brand Colors
+$nypl-red-light: #e9b9a7;
+$nypl-red-regular: #d0343a;
+$nypl-red-muted-regular: #bb1d12;
+$nypl-red-dark: #97272c;
+
+$nypl-yellow-light: #f9e08e;
+$nypl-yellow-regular: #ffb81d;
+$nypl-yellow-dark: #c99212;
+
+$nypl-green-light: #c5d5a5;
+$nypl-green-regular: #799a05;
+$nypl-green-dark: #497629;
+
+$nypl-turquoise-light: #b0e3e4;
+$nypl-turquoise-regular: #00a1b0;
+$nypl-turquoise-dark: #007079;
+
+$nypl-blue-light: #b1c9ea;
+$nypl-blue-regular: #0071ce;
+$nypl-blue-dark: #004b98;
+
+$nypl-purple-light: #daa9e3;
+$nypl-purple-regular: #8a1a9c;
+$nypl-purple-dark: #673165;

--- a/components/_patterns/00-base/global/01-colors/_colors-used.scss
+++ b/components/_patterns/00-base/global/01-colors/_colors-used.scss
@@ -1,1 +1,15 @@
-$color-border: $gray-light;
+// Theme Colors
+$color-books-and-more: $nypl-red-regular;
+$color-research: $nypl-turquoise-regular;
+$color-whats-on: $nypl-purple-regular;
+$color-spotlight: $nypl-purple-regular;
+$color-your-interests: $nypl-yellow-regular;
+$color-locations: $nypl-blue-regular;
+$color-support: $nypl-green-regular;
+$color-help: $nypl-blue-dark;
+
+// Utilities
+$color-success: $nypl-turquoise-regular;
+$color-error: $nypl-red-dark;
+$color-warning: $nypl-yellow-dark;
+$color-information: $nypl-blue-regular;

--- a/components/_patterns/00-base/global/01-colors/colors.yml
+++ b/components/_patterns/00-base/global/01-colors/colors.yml
@@ -1,22 +1,58 @@
 items:
   - name: $white
     value: white
-  - name: $near-white
-    value: '#f2f2f2'
-  - name: $gray-lightest
-    value: '#e5e5e5'
-  - name: $gray-lighter
-    value: '#ccc'
+  - name: $gray-xxlight
+    value: '#fafafa'
+  - name: $gray-xlight
+    value: '#f5f5f5'
   - name: $gray-light
-    value: '#999'
-  - name: $gray
-    value: '#666'
+    value: '#e0e0e0'
+  - name: $gray-medium
+    value: '#bdbdbd'
   - name: $gray-dark
-    value: '#4c4c4c'
-  - name: $gray-darker
-    value: '#333'
+    value: '#616161'
+  - name: $gray-xdark
+    value: '#424242'
   - name: $black
     value: black
+  - name: $nypl-red-light
+    value: '#e9b9a7'
+  - name: $nypl-red-regular
+    value: '#d0343a'
+  - name: $nypl-red-muted-regular
+    value: '#bb1d12'
+  - name: $nypl-red-dark
+    value: '#97272c'
+  - name: $nypl-yellow-light
+    value: '#f9e08e'
+  - name: $nypl-yellow-regular
+    value: '#ffb81d'
+  - name: $nypl-yellow-dark
+    value: '#c99212'
+  - name: $nypl-green-light
+    value: '#c5d5a5'
+  - name: $nypl-green-regular
+    value: '#799a05'
+  - name: $nypl-green-dark
+    value: '#497629'
+  - name: $nypl-turquoise-light
+    value: '#b0e3e4'
+  - name: $nypl-turquoise-regular
+    value: '#00a1b0'
+  - name: $nypl-turquoise-dark
+    value: '#007079'
+  - name: $nypl-blue-light
+    value: '#b1c9ea'
+  - name: $nypl-blue-regular
+    value: '#0071ce'
+  - name: $nypl-blue-dark
+    value: '#004b98'
+  - name: $nypl-purple-light
+    value: '#daa9e3'
+  - name: $nypl-purple-regular
+    value: '#8a1a9c'
+  - name: $nypl-purple-dark
+    value: '#673165'
 meta:
   description: >-
     To add to these items, use Sass variables that start with <code>$</code> in

--- a/components/_patterns/00-base/global/animations/_animation.scss
+++ b/components/_patterns/00-base/global/animations/_animation.scss
@@ -22,7 +22,7 @@
 }
 
 .demo-animate {
-  background-color: $gray-lightest;
+  background-color: $gray-light;
   border-radius: 8px;
   cursor: pointer;
   padding: 1em;

--- a/components/_patterns/00-base/global/base/_pl-base.scss
+++ b/components/_patterns/00-base/global/base/_pl-base.scss
@@ -11,7 +11,7 @@
   .sg-subtype h2 {
     font-size: 3rem;
     text-transform: uppercase;
-    background-color: $gray-darker;
+    background-color: $gray-dark;
 
     a {
       @include wrapper(

--- a/components/_patterns/00-base/layouts/grid/_grid-item-divider.scss
+++ b/components/_patterns/00-base/layouts/grid/_grid-item-divider.scss
@@ -7,7 +7,7 @@
     position: relative;
 
     &::after {
-      background-color: $gray-lighter;
+      background-color: $gray-light;
       content: "";
       display: block;
       height: 100%;

--- a/components/_patterns/01-atoms/01-links/link/_link.scss
+++ b/components/_patterns/01-atoms/01-links/link/_link.scss
@@ -1,5 +1,5 @@
 /// Link
-$color-link: $gray-darker;
+$color-link: $gray-dark;
 $color-link--hover: $gray-light;
 
 @mixin link {

--- a/components/_patterns/01-atoms/02-text/00-headings/_headings.scss
+++ b/components/_patterns/01-atoms/02-text/00-headings/_headings.scss
@@ -3,7 +3,7 @@
 // All arguments are optional. If not defined, the defaults below will be used
 //
 
-$color-heading: $gray-darker;
+$color-heading: $gray-dark;
 
 @mixin heading-xl($font-family: $font-heading, $font-size: 2rem, $line-height: 1.4, $color: $color-heading, $color-link: inherit, $color-link-hover: inherit, $font-weight: 700, $margin: 0 0 0.5em) {
   color: #{$color};

--- a/components/_patterns/01-atoms/02-text/text/_text.scss
+++ b/components/_patterns/01-atoms/02-text/text/_text.scss
@@ -11,7 +11,7 @@
 }
 
 body {
-  color: $gray;
+  color: $gray-medium;
 
   @include body-copy;
 }
@@ -22,7 +22,7 @@ body {
 
 .blockquote {
   font-style: italic;
-  border-left: solid 3px $color-border;
+  border-left: solid 3px $color-books-and-more;
   margin-left: 1em;
   padding-left: 1em;
 }

--- a/components/_patterns/01-atoms/05-forms/select/_select.scss
+++ b/components/_patterns/01-atoms/05-forms/select/_select.scss
@@ -1,14 +1,14 @@
 // CSS-only select styling (from https://github.com/filamentgroup/select-css)
 
 .form-item__dropdown {
-  border: 1px solid $gray-lightest;
+  border: 1px solid $gray-xxlight;
   display: block;
   position: relative;
 
   &::after {
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-top: 9px solid $gray-darker;
+    border-top: 9px solid $gray-dark;
     content: " ";
     position: absolute;
     top: 42%;
@@ -26,7 +26,7 @@
 }
 
 .form-item__select {
-  border: 1px solid $gray-lightest;
+  border: 1px solid $gray-xxlight;
   height: 41px; // set height required for discrepancy between .form-item__dropdown border and the select :focus border
   font-size: 16px;
   margin: 0;
@@ -60,7 +60,7 @@
     appearance: none;
 
     &:focus {
-      border-color: $gray;
+      border-color: $gray-medium;
       border-radius: 0;
     }
   }

--- a/components/_patterns/01-atoms/05-forms/textfields/_textfields.scss
+++ b/components/_patterns/01-atoms/05-forms/textfields/_textfields.scss
@@ -1,5 +1,5 @@
 .form-item {
-  color: $gray;
+  color: $gray-medium;
   margin-bottom: 1em;
   max-width: 32em;
 
@@ -18,7 +18,7 @@
 }
 
 .form-item__textfield {
-  border: 1px solid $gray-lightest;
+  border: 1px solid $gray-xxlight;
   padding: 0.6em;
   max-width: 100%;
 

--- a/components/_patterns/01-atoms/06-buttons/_buttons.scss
+++ b/components/_patterns/01-atoms/06-buttons/_buttons.scss
@@ -1,4 +1,4 @@
-@mixin button($bg:$black, $color:$white, $hoverBg: $gray, $hoverColor: $white) {
+@mixin button($bg:$black, $color:$white, $hoverBg: $gray-medium, $hoverColor: $white) {
   background-color: $bg;
   border: none;
   color: $color;
@@ -20,7 +20,7 @@
 }
 
 @mixin button-alt {
-  @include button($gray, $white, $black);
+  @include button($gray-medium, $white, $black);
 
   font-weight: 600;
   font-size: 0.7rem;
@@ -28,7 +28,7 @@
 }
 
 @mixin button-alt-2 {
-  @include button($gray-lightest, $black, $gray-lighter);
+  @include button($gray-xxlight, $black, $gray-xlight);
 
   font-size: 0.8rem;
   font-weight: 600;

--- a/components/_patterns/01-atoms/07-tables/_tables.scss
+++ b/components/_patterns/01-atoms/07-tables/_tables.scss
@@ -1,5 +1,5 @@
 $table-gray: #f8f8f8;
-$table-border: $gray-lightest;
+$table-border: $gray-xxlight;
 
 .table {
   border: 1px solid $table-border;

--- a/components/_patterns/01-atoms/09-menu/tab/_tab.scss
+++ b/components/_patterns/01-atoms/09-menu/tab/_tab.scss
@@ -1,9 +1,9 @@
 .tabs__link,
 .tabs__link--local-tasks {
-  background-color: $near-white;
-  border: 1px solid $gray-lightest;
+  background-color: $white;
+  border: 1px solid $gray-xxlight;
   border-bottom: none;
-  color: $gray;
+  color: $gray-medium;
   display: block;
   font-size: 1.1rem;
   font-weight: 600;
@@ -13,7 +13,7 @@
   transition: color 0.3s;
 
   @include large {
-    border-bottom: 1px solid $gray-lightest;
+    border-bottom: 1px solid $gray-xxlight;
     border-left: none;
     display: inline-block;
     font-size: 1rem;
@@ -24,21 +24,21 @@
   }
 
   &:hover {
-    background-color: $gray-lightest;
-    color: $gray-darker;
+    background-color: $gray-xxlight;
+    color: $gray-xdark;
   }
 
   &.is-active {
-    background-color: $gray;
-    border: 1px solid $gray;
+    background-color: $gray-medium;
+    border: 1px solid $gray-medium;
     color: $white;
 
     @include large {
       background-color: $white;
-      border: 1px solid $gray-lightest;
-      border-bottom: 1px solid $gray;
+      border: 1px solid $gray-xxlight;
+      border-bottom: 1px solid $gray-medium;
       border-left: none;
-      color: $gray;
+      color: $gray-medium;
     }
   }
 }

--- a/components/_patterns/02-molecules/accordion-item/_accordion-item.scss
+++ b/components/_patterns/02-molecules/accordion-item/_accordion-item.scss
@@ -1,5 +1,5 @@
 .accordion-term {
-  border-top: 1px solid $gray-lightest;
+  border-top: 1px solid $gray-xxlight;
   color: $gray-dark;
   cursor: pointer;
   display: block;
@@ -14,11 +14,11 @@
   }
 
   &:hover {
-    color: $gray;
+    color: $gray-medium;
   }
 
   &.is-active {
-    color: $gray;
+    color: $gray-medium;
 
     &::before {
       content: "-";

--- a/components/_patterns/02-molecules/card/_card.scss
+++ b/components/_patterns/02-molecules/card/_card.scss
@@ -11,7 +11,7 @@
   @include heading-medium($font-size: 1rem);
   @include no-bottom;
 
-  color: $gray;
+  color: $gray-medium;
 }
 
 .card__body {
@@ -28,6 +28,6 @@
 
 // Variations
 .card--bg {
-  background-color: $gray-lightest;
+  background-color: $gray-xxlight;
   padding: 1em;
 }

--- a/components/_patterns/02-molecules/info-box/_info-box.scss
+++ b/components/_patterns/02-molecules/info-box/_info-box.scss
@@ -1,5 +1,5 @@
 .info-box {
-  background-color: $gray-lightest;
+  background-color: $gray-xxlight;
   margin-bottom: 2%;
   padding: 1em;
   width: 100%;

--- a/components/_patterns/02-molecules/menus/breadcrumbs/_breadcrumbs.scss
+++ b/components/_patterns/02-molecules/menus/breadcrumbs/_breadcrumbs.scss
@@ -14,7 +14,7 @@ $breadcrumb-active: #bbb;
 }
 
 .breadcrumb__link:hover {
-  color: $gray;
+  color: $gray-medium;
 }
 
 .breadcrumb__item {

--- a/components/_patterns/02-molecules/menus/main-menu/_00-main-menu.scss
+++ b/components/_patterns/02-molecules/menus/main-menu/_00-main-menu.scss
@@ -44,11 +44,11 @@ $main-menu-medium: 43em;
   border-bottom: none;
   height: 0;
   overflow: hidden;
-  background-color: $near-white;
+  background-color: $white;
   width: 100%;
 
   @include breakpoint($main-menu-medium) {
-    background-color: $gray-lightest;
+    background-color: $gray-xxlight;
     display: none;
     height: auto;
     left: 0;

--- a/components/_patterns/02-molecules/menus/main-menu/_01-main-menu-item.scss
+++ b/components/_patterns/02-molecules/menus/main-menu/_01-main-menu-item.scss
@@ -22,7 +22,7 @@
 
   &:hover {
     .main-menu__link::after {
-      color: $gray;
+      color: $gray-medium;
     }
   }
 }
@@ -59,7 +59,7 @@
   // See main-menu.js
   &--open {
     background-color: $black;
-    color: $near-white;
+    color: $white;
 
     &::after {
       border-top-color: transparent;

--- a/components/_patterns/02-molecules/menus/main-menu/_02-main-menu-link.scss
+++ b/components/_patterns/02-molecules/menus/main-menu/_02-main-menu-link.scss
@@ -25,7 +25,7 @@
     &.active,
     &:active,
     &:hover {
-      color: $gray-lighter;
+      color: $gray-xlight;
     }
 
     &::after {
@@ -65,7 +65,7 @@
 }
 
 .main-menu--sub-2 {
-  background-color: $gray-lightest;
+  background-color: $gray-xxlight;
 }
 
 .main-menu__link--sub-2 {

--- a/components/_patterns/02-molecules/menus/tabs/_tabs.scss
+++ b/components/_patterns/02-molecules/menus/tabs/_tabs.scss
@@ -2,10 +2,10 @@
 .tabs__nav {
   @include list-reset;
 
-  border-bottom: 1px solid $gray-lightest;
+  border-bottom: 1px solid $gray-xxlight;
 
   @include large {
-    border-left: 1px solid $gray-lightest;
+    border-left: 1px solid $gray-xxlight;
     display: flex;
   }
 }

--- a/components/_patterns/02-molecules/pager/_pager.scss
+++ b/components/_patterns/02-molecules/pager/_pager.scss
@@ -26,7 +26,7 @@
 
   &.is-active,
   &:hover {
-    color: $gray;
+    color: $gray-medium;
   }
 }
 
@@ -51,7 +51,7 @@
 
   &:hover {
     &::before {
-      border-left-color: $gray;
+      border-left-color: $gray-medium;
     }
   }
 }
@@ -65,7 +65,7 @@
   &:hover {
     &::before {
       border-left-color: transparent;
-      border-right-color: $gray;
+      border-right-color: $gray-medium;
     }
   }
 }


### PR DESCRIPTION
Also updates references to Patternlab's sass variables. In Figma the designers have named these differently, so I've updated the `Grays/Neutrals` variables to reflect that.

Re PR #1, Removing the `01-` on the folder for `01-colors` breaks the `pl:scss-to-yaml` task in `emulsify-gulp`, as it seems to rely on a hardcoded link in that node_module on line 65 within `gulp-config.js`, so I've left it out of this PR. Brian, we might want to rethink whether or not it's worth our time—I'm leaning toward no.

```javascript
src: `${themeDir}/components/_patterns/00-base/global/01-colors/_color-vars.scss`,
```