### PR TITLE
RENO-303: Catalog Lists

### DIFF
--- a/components/_patterns/02-molecules/catalog-item/_catalog-item.scss
+++ b/components/_patterns/02-molecules/catalog-item/_catalog-item.scss
@@ -1,0 +1,42 @@
+.catalog-item {
+  border-bottom: 1px solid $gray-light;
+  list-style-type: none;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: $space-l;
+
+  &__icon {
+    align-self: stretch;
+    background-color: $gray-xlight;
+    background-position: center;
+    background-repeat: no-repeat;
+    border: 1px solid $gray-xlight;
+    display: flex;
+    flex: 0 0 200px;
+    justify-content: center;
+    padding: $space $space;
+    margin-right: $space;
+
+    &--book {
+      background-image: url('../images/icons/book-purple.svg');
+    }
+
+    &--cd,
+    &--audiobook {
+      background-image: url('../images/icons/cd-purple.svg');
+    }
+
+    &--movie {
+      background-image: url('../images/icons/movie-purple.svg');
+    }
+  }
+
+  &__content {
+    flex: 2 1 auto;
+    margin-right: $space;
+  }
+
+  &__ctas {
+    flex: 1 1 auto;
+  }
+}

--- a/components/_patterns/02-molecules/catalog-item/_catalog-item.scss
+++ b/components/_patterns/02-molecules/catalog-item/_catalog-item.scss
@@ -6,37 +6,16 @@
   padding-bottom: $space-l;
 
   &__icon {
-    align-self: stretch;
+    align-items: center;
     background-color: $gray-xlight;
-    background-position: center;
-    background-repeat: no-repeat;
-    border: 1px solid $gray-xlight;
     display: flex;
-    flex: 0 0 200px;
+    flex: 0 0 160px;
     justify-content: center;
-    padding: $space $space;
     margin-right: $space;
-
-    &--book {
-      background-image: url('../images/icons/book-purple.svg');
-    }
-
-    &--cd,
-    &--audiobook {
-      background-image: url('../images/icons/cd-purple.svg');
-    }
-
-    &--movie {
-      background-image: url('../images/icons/movie-purple.svg');
-    }
   }
 
   &__content {
-    flex: 2 1 auto;
-    margin-right: $space;
-  }
-
-  &__ctas {
     flex: 1 1 auto;
+    margin-right: $space;
   }
 }

--- a/components/_patterns/02-molecules/catalog-item/catalog-item.twig
+++ b/components/_patterns/02-molecules/catalog-item/catalog-item.twig
@@ -18,12 +18,12 @@
 <li {{ bem(catalog_item_base_class, (catalog_item_modifiers), catalog_blockname) }}>
   <div {{ bem('icon', [], catalog_item_base_class) }}>
     {% if catalog_item__image %}
-      {# {% block catalog_item__image %} #}
-      {% include "@atoms/04-images/00-image/responsive-image.twig" with {
-        output_image_tag: true,
-        img_src: catalog_item__image_src,
-      } %}
-      {# {% endblock %} #}
+      {% block catalog_item__image %}
+        {% include "@atoms/images/image/responsive-image.twig" with {
+          output_image_tag: true,
+          img_src: catalog_item__image_src,
+        } %}
+      {% endblock %}
     {% else %}
       {% include "@atoms/images/icons/_icon.twig" with {
         icon_name: catalog_item__icon,

--- a/components/_patterns/02-molecules/catalog-item/catalog-item.twig
+++ b/components/_patterns/02-molecules/catalog-item/catalog-item.twig
@@ -8,7 +8,7 @@
 {% set catalog_item_base_class = 'catalog-item' %}
 
 <li {{ bem(catalog_item_base_class, (catalog_item_modifiers), catalog_blockname) }}>
-  <div {{ bem('icon', [media_type], catalog_item_base_class) }}>
+  <div {{ bem('icon', [catalog_item__media_type], catalog_item_base_class) }}>
     {% if image is defined %}
       {% block catalog_item__image %}
         {% include "@atoms/04-images/00-image/responsive-image.twig" with {
@@ -16,26 +16,22 @@
           img_src: catalog_item__image_src,
         } %}
       {% endblock %}
+    {% else %}
+      {% include "@atoms/images/icons/_icon.twig" with {
+        icon_name: catalog_item__media_type,
+        icon_modifiers: ['xlarge'],
+      } %}
     {% endif %}
   </div>
 
   <div {{ bem('content', [], catalog_item_base_class) }}>
-    <h3>{{ title|length > 50 ? title|slice(0, 50) ~ '...' : title }}</h3>
+    <h3>{{ catalog_item__title }}</h3>
 
-    <span class="tag">{{ year }}</span>
+    <span class="tag">{{ catalog_item__year }}</span>
+    <span class="tag">{{ catalog_item__media_type|title }}</span>
 
-    {% if media_type == 'cd' %}
-      <span class="tag">{{ media_type|upper }}</span>
-    {% else %}
-      <span class="tag">{{ media_type|title }}</span>
-    {% endif %}
-
-    <div class="">By {{ author.first }} {{ author.last }}</div>
+    <div class="">By {{ catalog_item__author }}<div>
 
     <p>Available onsite at specific locations. <a href="#" class="btn-text">View Detail<span class="icon icon-arrow-right blue"></span></a></p>
-  </div>
-
-  <div {{ bem('ctas', [], catalog_item_base_class) }}>
-    <button href="{{ how_to_view_link }}" aria-labelledby="{{ title }}, How to View" class="btn btn-outline fluid">How to View</button>
   </div>
 </li>

--- a/components/_patterns/02-molecules/catalog-item/catalog-item.twig
+++ b/components/_patterns/02-molecules/catalog-item/catalog-item.twig
@@ -1,0 +1,41 @@
+{#
+  Variables:
+  ongoing - Whether this is an ongoing event
+  date_tile__start_date - The event's starting date
+  date_tile__end_date - The event's ending date
+#}
+
+{% set catalog_item_base_class = 'catalog-item' %}
+
+<li {{ bem(catalog_item_base_class, (catalog_item_modifiers), catalog_blockname) }}>
+  <div {{ bem('icon', [media_type], catalog_item_base_class) }}>
+    {% if image is defined %}
+      {% block catalog_item__image %}
+        {% include "@atoms/04-images/00-image/responsive-image.twig" with {
+          output_image_tag: true,
+          img_src: catalog_item__image_src,
+        } %}
+      {% endblock %}
+    {% endif %}
+  </div>
+
+  <div {{ bem('content', [], catalog_item_base_class) }}>
+    <h3>{{ title|length > 50 ? title|slice(0, 50) ~ '...' : title }}</h3>
+
+    <span class="tag">{{ year }}</span>
+
+    {% if media_type == 'cd' %}
+      <span class="tag">{{ media_type|upper }}</span>
+    {% else %}
+      <span class="tag">{{ media_type|title }}</span>
+    {% endif %}
+
+    <div class="">By {{ author.first }} {{ author.last }}</div>
+
+    <p>Available onsite at specific locations. <a href="#" class="btn-text">View Detail<span class="icon icon-arrow-right blue"></span></a></p>
+  </div>
+
+  <div {{ bem('ctas', [], catalog_item_base_class) }}>
+    <button href="{{ how_to_view_link }}" aria-labelledby="{{ title }}, How to View" class="btn btn-outline fluid">How to View</button>
+  </div>
+</li>

--- a/components/_patterns/02-molecules/catalog-item/catalog-item.twig
+++ b/components/_patterns/02-molecules/catalog-item/catalog-item.twig
@@ -7,18 +7,26 @@
 
 {% set catalog_item_base_class = 'catalog-item' %}
 
+{% if catalog_item__media_type == 'electronic resource' %}
+  {% set catalog_item__icon = 'computer' %}
+{% elseif catalog_item__media_type == 'music' or 'audiobook' %}
+  {% set catalog_item__icon = 'cd' %}
+{% else %}
+  {% set catalog_item__icon = catalog_item__media_type  %}
+{% endif %}
+
 <li {{ bem(catalog_item_base_class, (catalog_item_modifiers), catalog_blockname) }}>
-  <div {{ bem('icon', [catalog_item__media_type], catalog_item_base_class) }}>
-    {% if image is defined %}
-      {% block catalog_item__image %}
-        {% include "@atoms/04-images/00-image/responsive-image.twig" with {
-          output_image_tag: true,
-          img_src: catalog_item__image_src,
-        } %}
-      {% endblock %}
+  <div {{ bem('icon', [], catalog_item_base_class) }}>
+    {% if catalog_item__image %}
+      {# {% block catalog_item__image %} #}
+      {% include "@atoms/04-images/00-image/responsive-image.twig" with {
+        output_image_tag: true,
+        img_src: catalog_item__image_src,
+      } %}
+      {# {% endblock %} #}
     {% else %}
       {% include "@atoms/images/icons/_icon.twig" with {
-        icon_name: catalog_item__media_type,
+        icon_name: catalog_item__icon,
         icon_modifiers: ['xlarge'],
       } %}
     {% endif %}
@@ -27,11 +35,16 @@
   <div {{ bem('content', [], catalog_item_base_class) }}>
     <h3>{{ catalog_item__title }}</h3>
 
-    <span class="tag">{{ catalog_item__year }}</span>
+    <span class="tag">{{ catalog_item__year }}</span> | 
     <span class="tag">{{ catalog_item__media_type|title }}</span>
 
-    <div class="">By {{ catalog_item__author }}<div>
+    <div>By {{ catalog_item__author }}<div>
 
-    <p>Available onsite at specific locations. <a href="#" class="btn-text">View Detail<span class="icon icon-arrow-right blue"></span></a></p>
+    <p>{{ catalog_item__availability_level }}
+    {% include "@atoms/links/link/more-link.twig" with {
+      link_content: 'View Detail',
+      link_url: address_bar__directions_url,
+    } %}
+    </p>
   </div>
 </li>

--- a/components/_patterns/02-molecules/catalog-item/catalog-item.yml
+++ b/components/_patterns/02-molecules/catalog-item/catalog-item.yml
@@ -1,5 +1,5 @@
 catalog_item__media_type:
-  "book"
+  "audiobook"
 
 catalog_item__title:
   "The Anna Atkins volumes Long Title That Wraps [electronic resource]"
@@ -10,11 +10,7 @@ catalog_item__author:
 catalog_item__year:
   "1999"
 
-type_of_file:
-  "File type"
+catalog_item__availability_level:
+  "Available onsite at specific locations."
 
-availability:
-  true
-
-
-catalog_item__link__url:
+catalog_item__link__url: '#'

--- a/components/_patterns/02-molecules/catalog-item/catalog-item.yml
+++ b/components/_patterns/02-molecules/catalog-item/catalog-item.yml
@@ -1,0 +1,30 @@
+media_type:
+  "book"
+
+title:
+  "Catalog item title"
+
+author:
+  first:
+    "First"
+  last:
+    "Last"
+
+year:
+  "Catalog item year"
+
+type_of_file:
+  "File type"
+
+availability:
+  true
+
+detail_link:
+  "#"
+
+view_link:
+  "#"
+
+add_to_list_link:
+  "#"
+

--- a/components/_patterns/02-molecules/catalog-item/catalog-item.yml
+++ b/components/_patterns/02-molecules/catalog-item/catalog-item.yml
@@ -1,17 +1,14 @@
-media_type:
+catalog_item__media_type:
   "book"
 
-title:
-  "Catalog item title"
+catalog_item__title:
+  "The Anna Atkins volumes Long Title That Wraps [electronic resource]"
 
-author:
-  first:
-    "First"
-  last:
-    "Last"
+catalog_item__author:
+  "Jason McAuthor"
 
-year:
-  "Catalog item year"
+catalog_item__year:
+  "1999"
 
 type_of_file:
   "File type"
@@ -19,12 +16,5 @@ type_of_file:
 availability:
   true
 
-detail_link:
-  "#"
 
-view_link:
-  "#"
-
-add_to_list_link:
-  "#"
-
+catalog_item__link__url:

--- a/components/_patterns/02-molecules/catalog-item/catalog-item~with-image.yml
+++ b/components/_patterns/02-molecules/catalog-item/catalog-item~with-image.yml
@@ -1,36 +1,19 @@
-img:
-  src:
-    "#"
-  alt:
-    "alt"
+catalog_item__media_type:
+  "audiobook"
 
-media_type:
-  "book"
+catalog_item__title:
+  "The Anna Atkins volumes Long Title That Wraps [electronic resource]"
 
-title:
-  "Catalog item title"
+catalog_item__author:
+  "Jason McAuthor"
 
-author:
-  first:
-    "First"
-  last:
-    "Last"
+catalog_item__year:
+  "1999"
 
-year:
-  "Catalog item year"
+catalog_item__availability_level:
+  "Available onsite at specific locations."
 
-type_of_file:
-  "File type"
+catalog_item__link__url: '#'
 
-availability:
-  true
-
-detail_link:
-  "#"
-
-view_link:
-  "#"
-
-add_to_list_link:
-  "#"
-
+catalog_item__image: true
+catalog_item__image_src: 'https://placeimg.com/330/400/people'

--- a/components/_patterns/02-molecules/catalog-item/catalog-item~with-image.yml
+++ b/components/_patterns/02-molecules/catalog-item/catalog-item~with-image.yml
@@ -1,0 +1,36 @@
+img:
+  src:
+    "#"
+  alt:
+    "alt"
+
+media_type:
+  "book"
+
+title:
+  "Catalog item title"
+
+author:
+  first:
+    "First"
+  last:
+    "Last"
+
+year:
+  "Catalog item year"
+
+type_of_file:
+  "File type"
+
+availability:
+  true
+
+detail_link:
+  "#"
+
+view_link:
+  "#"
+
+add_to_list_link:
+  "#"
+

--- a/components/_patterns/02-molecules/catalog-item/catalog-item~with-image.yml
+++ b/components/_patterns/02-molecules/catalog-item/catalog-item~with-image.yml
@@ -16,4 +16,4 @@ catalog_item__availability_level:
 catalog_item__link__url: '#'
 
 catalog_item__image: true
-catalog_item__image_src: 'https://placeimg.com/330/400/people'
+catalog_item__image_src: 'http://placeimg.com/400/300/arch'


### PR DESCRIPTION
Jira Ticket: http://jira.nypl.org/browse/RENO-303

## **This PR does the following:**
- Creates the Catalog list item molecule and organisms

### Front End Review:
- [ ] View the examples in Pattern Lab ([molecule](http://localhost:3000/pattern-lab/public/?p=viewall-molecules-catalog-item) | [organism]()) and verify all variations are displaying appropriately _at all screen sizes_
- [ ] Compare to [catalog list block in Figma](https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Working-Component-Library?node-id=5453%3A6681)

### Todo:
- [ ] Need to define the default image/icon version based on media type
  - [ ] Need to verify with Courtney that the following are the only media types: Books, CDs, Electronic Resources, Movies
- [x] Image version
- [ ] Book titles = `h3`
- [ ] How do we get unique id in catalog lists?
- [ ] `"View Detail" is an a with target of a catalog item page and aria-describedby pointing to the unique id of the h3`

### Questions:
[Documentation:](https://nypl.github.io/nypl-design-system-docs/#/organisms/section-catalog-item-list)
- [ ] HTML order. What did Brian do for the events module?
  - **Update from Willa:** Using the solution proposed [here](https://inclusive-components.design/cards/)
- [x] "View detail >" vs "View Details" << which string do we want? 
  - **Update from Jack:** View Detail with arrow
- [ ] IA and Content Massing designs have diverged
- [ ] Availability message. What's the IA for other variants?
- [ ] Would we like to see a variation for every of the above media types? Is that helpful?